### PR TITLE
feat: console link on landing page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,11 @@ const config = {
           },
           { to: "/blog", label: "Blog", position: "left" },
           {
+            href: "https://console.juno.build",
+            label: "Console",
+            position: "right",
+          },
+          {
             href: "https://twitter.com/junobuild",
             label: "Twitter",
             position: "right",


### PR DESCRIPTION
Maybe there's already a link but I couldn't find it. Close & edit at will.
<img width="481" alt="Screenshot 2023-02-11 at 14 45 59" src="https://user-images.githubusercontent.com/6930756/218261339-24c8738f-b4ed-4d0d-b2dd-20d8a271e9de.png">
