### PR TITLE
docs: fix typos and links

### DIFF
--- a/docs/add-juno-to-an-app/create-a-satellite.md
+++ b/docs/add-juno-to-an-app/create-a-satellite.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 
 Before integrating Juno into your JavaScript app, you need to create a [satellite].
 
-1. In the [Juno console](https://console.build.com), click "Launch a new satellite".
-2. Enter a desired name for your satellite (note: this is for display purposes only and does not need to be unique).
+1. In the [Juno console](https://console.juno.build), click "Launch a new satellite".
+2. Enter a name for your satellite (note: this is for display purposes only and does not need to be unique).
 3. Click **Create a Satellite.**. Juno will automatically generate a unique ID for your new [satellite].
 4. The platform will then create your [satellite] smart contract and provision its resources.
 5. Once the process is complete, click **Continue** to access the overview page.

--- a/docs/add-juno-to-an-app/install-the-sdk-and-initialize-juno.md
+++ b/docs/add-juno-to-an-app/install-the-sdk-and-initialize-juno.md
@@ -8,7 +8,7 @@ To connect Juno to your web app, you need to install the SDK and initialize your
 
 :::tip
 
-If you plan to use Juno for [hosting](../build/hosting.md) purposes only, you can skip these steps, as they are required for rich features such as the [datastore](../build/datastore.md) or [storage](../build/storage.md).
+If you plan to use Juno for [hosting](../build/hosting.md) purposes only, you can skip these steps, as they are only required for rich features such as the [datastore](../build/datastore.md) or [storage](../build/storage.md).
 
 :::
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,7 +8,7 @@ Welcome to Juno, an open-source Blockchain-as-a-Service platform that makes buil
 
 Unlike traditional Backend-as-a-Service (BaaS) platforms like Google Firebase or AWS Amplify, Juno runs entirely on the blockchain.
 
-It provides you the ability to outsource all the behind-the-scenes aspects of your web or mobile development, giving you the ability to focus on the frontend.
+It allows you to outsource all the behind-the-scenes aspects of your web or mobile development, giving you the ability to focus on the frontend.
 
 At Juno, privacy is a top priority and the platform operates without controlling your data or work. With Juno, you truly own your creations.
 


### PR DESCRIPTION
Couple of issues I spotted while reading the first pages of the getting started guide.